### PR TITLE
[API][Frontend] Implement core chat messaging with streaming

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,10 +1,5 @@
 import type { NextConfig } from "next"
-import path from "path"
 
-const nextConfig: NextConfig = {
-  turbopack: {
-    root: path.resolve(__dirname),
-  },
-}
+const nextConfig: NextConfig = {}
 
 export default nextConfig

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@ai-sdk/google": "^3.0.53",
         "@ai-sdk/groq": "^3.0.31",
+        "@ai-sdk/react": "^3.0.140",
         "@base-ui/react": "^1.3.0",
         "@langchain/textsplitters": "^1.0.1",
         "@supabase/ssr": "^0.9.0",
@@ -48,9 +49,9 @@
       }
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "3.0.79",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.79.tgz",
-      "integrity": "sha512-Wk2QJpqd0em5YcR49uoMCy9msyANAYgjXdlRcqqRt2fz4rNLnMMrKOlLwAXoFzR1ElR3bj4e/k6hscRfjpzSGA==",
+      "version": "3.0.80",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.80.tgz",
+      "integrity": "sha512-uM7kpZB5l977lW7+2X1+klBUxIZQ78+1a9jHlaHFEzcOcmmslTl3sdP0QqfuuBcO0YBM2gwOiqVdp8i4TRQYcw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
@@ -123,6 +124,24 @@
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/react": {
+      "version": "3.0.140",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-3.0.140.tgz",
+      "integrity": "sha512-wCL9iTrzoW8ppYVrz7BFCurCEqW6hjCoFFyxkrS3us2pSbUlQpXHmrprFQevzfa2PJXiF5hss7ZN8ZNdiZW//A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider-utils": "4.0.21",
+        "ai": "6.0.138",
+        "swr": "^2.2.5",
+        "throttleit": "2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -3600,12 +3619,12 @@
       }
     },
     "node_modules/ai": {
-      "version": "6.0.137",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.137.tgz",
-      "integrity": "sha512-9e/mNMTmXmMkmldEJPIumy9FFBuUWHUyj2yF8EglC3VVOhVVBwlnpeHYSFKdNc13Jj6Hso3EJcZioMaofgCs4A==",
+      "version": "6.0.138",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.138.tgz",
+      "integrity": "sha512-49OfPe0f5uxJ6jUdA5BBXjIinP6+ZdYfAtpF2aEH64GA5wPcxH2rf/TBUQQ0bbamBz/D+TLMV18xilZqOC+zaA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "3.0.79",
+        "@ai-sdk/gateway": "3.0.80",
         "@ai-sdk/provider": "3.0.8",
         "@ai-sdk/provider-utils": "4.0.21",
         "@opentelemetry/api": "1.9.0"
@@ -11331,6 +11350,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.1.tgz",
+      "integrity": "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/tabbable": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
@@ -11378,6 +11410,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tiny-invariant": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@ai-sdk/google": "^3.0.53",
     "@ai-sdk/groq": "^3.0.31",
+    "@ai-sdk/react": "^3.0.140",
     "@base-ui/react": "^1.3.0",
     "@langchain/textsplitters": "^1.0.1",
     "@supabase/ssr": "^0.9.0",

--- a/src/app/(chat)/chat/[id]/page.tsx
+++ b/src/app/(chat)/chat/[id]/page.tsx
@@ -1,3 +1,9 @@
+import { notFound, redirect } from "next/navigation"
+import { createSessionClient } from "@/lib/supabase/session"
+import { createServerClient } from "@/lib/supabase/server"
+import { Chat } from "@/components/chat/chat"
+import type { UIMessage } from "ai"
+
 export default async function ChatPage({
   params,
 }: {
@@ -5,9 +11,33 @@ export default async function ChatPage({
 }) {
   const { id } = await params
 
-  return (
-    <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
-      Chat {id}
-    </div>
-  )
+  const session = await createSessionClient()
+  const {
+    data: { user },
+  } = await session.auth.getUser()
+  if (!user) redirect("/login")
+
+  const db = createServerClient()
+
+  const { data: chat } = await db
+    .from("chats")
+    .select("*")
+    .eq("id", id)
+    .single()
+
+  if (!chat || chat.user_id !== user.id) notFound()
+
+  const { data: dbMessages } = await db
+    .from("messages")
+    .select("*")
+    .eq("chat_id", id)
+    .order("created_at", { ascending: true })
+
+  const initialMessages: UIMessage[] = (dbMessages ?? []).map((msg) => ({
+    id: msg.id,
+    role: msg.role as "user" | "assistant",
+    parts: msg.parts,
+  }))
+
+  return <Chat chatId={id} initialMessages={initialMessages} />
 }

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,0 +1,79 @@
+import { convertToModelMessages, generateText, streamText } from "ai"
+import { google } from "@ai-sdk/google"
+import { groq } from "@ai-sdk/groq"
+import { createSessionClient } from "@/lib/supabase/session"
+import { createServerClient } from "@/lib/supabase/server"
+import { NextResponse } from "next/server"
+import type { UIMessage } from "ai"
+import type { SupabaseClient } from "@supabase/supabase-js"
+
+async function generateChatTitle(
+  db: SupabaseClient,
+  chatId: string,
+  firstMessageText: string
+) {
+  try {
+    const { text } = await generateText({
+      model: groq("llama-3.3-70b-versatile"),
+      prompt: `Generate a short title (max 6 words) for a chat that starts with: "${firstMessageText}". Reply with only the title, no quotes.`,
+    })
+    await db.from("chats").update({ title: text.trim() }).eq("id", chatId)
+  } catch {}
+}
+
+export async function POST(request: Request) {
+  const session = await createSessionClient()
+  const {
+    data: { user },
+  } = await session.auth.getUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const { messages, chatId }: { messages: UIMessage[]; chatId: string } =
+    await request.json()
+
+  const db = createServerClient()
+
+  const { data: chat } = await db
+    .from("chats")
+    .select("*")
+    .eq("id", chatId)
+    .single()
+
+  if (!chat || chat.user_id !== user.id) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 })
+  }
+
+  const lastMessage = messages[messages.length - 1]
+  const isFirstMessage = messages.length === 1
+  const firstMessageText =
+    lastMessage.parts.find((p) => p.type === "text")?.text ?? ""
+
+  await db.from("messages").insert({
+    chat_id: chatId,
+    role: "user",
+    parts: lastMessage.parts,
+    attachments: [],
+  })
+
+  const result = streamText({
+    model: groq("llama-3.3-70b-versatile"),
+    messages: await convertToModelMessages(messages),
+    onFinish: async ({ text }) => {
+      await db.from("messages").insert({
+        chat_id: chatId,
+        role: "assistant",
+        parts: [{ type: "text", text }],
+        attachments: [],
+      })
+      await db
+        .from("chats")
+        .update({ updated_at: new Date().toISOString() })
+        .eq("id", chatId)
+      if (isFirstMessage && chat.title === "New Chat") {
+        void generateChatTitle(db, chatId, firstMessageText)
+      }
+    },
+  })
+
+  return result.toUIMessageStreamResponse()
+}

--- a/src/app/api/chats/route.ts
+++ b/src/app/api/chats/route.ts
@@ -24,7 +24,7 @@ export async function POST(request: Request) {
   if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
 
   const body = await request.json()
-  const { title = "New Chat", model = "google/gemini-2.0-flash-exp" } = body
+  const { title = "New Chat", model = "google/gemini-2.0-flash" } = body
 
   const db = createServerClient()
   const { data: chat, error } = await db

--- a/src/app/api/messages/route.ts
+++ b/src/app/api/messages/route.ts
@@ -1,0 +1,43 @@
+import { createSessionClient } from "@/lib/supabase/session"
+import { createServerClient } from "@/lib/supabase/server"
+import { NextResponse } from "next/server"
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url)
+  const chatId = searchParams.get("chatId")
+  if (!chatId) return NextResponse.json({ error: "chatId required" }, { status: 400 })
+
+  const session = await createSessionClient()
+  const {
+    data: { user },
+  } = await session.auth.getUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const db = createServerClient()
+
+  const { data: chat } = await db
+    .from("chats")
+    .select("user_id")
+    .eq("id", chatId)
+    .single()
+
+  if (!chat || chat.user_id !== user.id) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 })
+  }
+
+  const { data: messages, error } = await db
+    .from("messages")
+    .select("*")
+    .eq("chat_id", chatId)
+    .order("created_at", { ascending: true })
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+
+  const uiMessages = (messages ?? []).map((msg) => ({
+    id: msg.id,
+    role: msg.role as "user" | "assistant",
+    parts: msg.parts,
+  }))
+
+  return NextResponse.json(uiMessages)
+}

--- a/src/components/chat/chat.tsx
+++ b/src/components/chat/chat.tsx
@@ -1,0 +1,50 @@
+"use client"
+
+import { useState } from "react"
+import { useChat } from "@ai-sdk/react"
+import { DefaultChatTransport } from "ai"
+import { useQueryClient } from "@tanstack/react-query"
+import { MessageList } from "./message-list"
+import { MessageInput } from "./message-input"
+import type { UIMessage } from "ai"
+
+interface ChatProps {
+  chatId: string
+  initialMessages: UIMessage[]
+}
+
+export function Chat({ chatId, initialMessages }: ChatProps) {
+  const queryClient = useQueryClient()
+  const [input, setInput] = useState("")
+
+  const { messages, sendMessage, status } = useChat({
+    messages: initialMessages,
+    transport: new DefaultChatTransport({
+      api: "/api/chat",
+      body: { chatId },
+    }),
+    onFinish: () => {
+      queryClient.invalidateQueries({ queryKey: ["chats"] })
+    },
+  })
+
+  const isLoading = status === "submitted" || status === "streaming"
+
+  const handleSend = () => {
+    if (!input.trim() || isLoading) return
+    sendMessage({ text: input })
+    setInput("")
+  }
+
+  return (
+    <div className="flex flex-1 flex-col overflow-hidden">
+      <MessageList messages={messages} isLoading={isLoading} />
+      <MessageInput
+        input={input}
+        isLoading={isLoading}
+        onInputChange={setInput}
+        onSend={handleSend}
+      />
+    </div>
+  )
+}

--- a/src/components/chat/message-input.tsx
+++ b/src/components/chat/message-input.tsx
@@ -1,0 +1,51 @@
+"use client"
+
+import { useRef } from "react"
+import { ArrowUp } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Textarea } from "@/components/ui/textarea"
+
+interface MessageInputProps {
+  input: string
+  isLoading: boolean
+  onInputChange: (value: string) => void
+  onSend: () => void
+}
+
+export function MessageInput({
+  input,
+  isLoading,
+  onInputChange,
+  onSend,
+}: MessageInputProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault()
+      onSend()
+    }
+  }
+
+  return (
+    <div className="flex items-end gap-2 p-4">
+      <Textarea
+        ref={textareaRef}
+        value={input}
+        onChange={(e) => onInputChange(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder="Message..."
+        rows={1}
+        className="min-h-10 max-h-40 flex-1 resize-none"
+        disabled={isLoading}
+      />
+      <Button
+        size="icon"
+        disabled={isLoading || !input.trim()}
+        onClick={onSend}
+      >
+        <ArrowUp className="size-4" />
+      </Button>
+    </div>
+  )
+}

--- a/src/components/chat/message-list.tsx
+++ b/src/components/chat/message-list.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+import type { UIMessage } from "ai"
+import { ChatMessage } from "./message"
+import { Skeleton } from "@/components/ui/skeleton"
+
+interface MessageListProps {
+  messages: UIMessage[]
+  isLoading: boolean
+}
+
+export function MessageList({ messages, isLoading }: MessageListProps) {
+  const bottomRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" })
+  }, [messages])
+
+  if (messages.length === 0) {
+    return (
+      <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+        Send a message to start the conversation
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-1 flex-col gap-4 overflow-y-auto p-4">
+      {messages.map((message) => (
+        <ChatMessage key={message.id} message={message} />
+      ))}
+      {isLoading && (
+        <div className="flex justify-start">
+          <div className="max-w-[75%] space-y-2 rounded-2xl bg-muted px-4 py-2.5">
+            <Skeleton className="h-3 w-48" />
+            <Skeleton className="h-3 w-32" />
+          </div>
+        </div>
+      )}
+      <div ref={bottomRef} />
+    </div>
+  )
+}

--- a/src/components/chat/message.tsx
+++ b/src/components/chat/message.tsx
@@ -1,0 +1,47 @@
+import ReactMarkdown from "react-markdown"
+import remarkGfm from "remark-gfm"
+import { cn } from "@/lib/utils"
+import type { UIMessage } from "ai"
+
+export function ChatMessage({ message }: { message: UIMessage }) {
+  const isUser = message.role === "user"
+
+  return (
+    <div className={cn("flex", isUser ? "justify-end" : "justify-start")}>
+      <div
+        className={cn(
+          "max-w-[75%] rounded-2xl px-4 py-2.5 text-sm",
+          isUser
+            ? "bg-primary text-primary-foreground"
+            : "bg-muted text-foreground"
+        )}
+      >
+        {message.parts.map((part, i) => {
+          if (part.type === "text") {
+            return isUser ? (
+              <p key={i} className="whitespace-pre-wrap break-words">
+                {part.text}
+              </p>
+            ) : (
+              <ReactMarkdown
+                key={i}
+                remarkPlugins={[remarkGfm]}
+                components={{
+                  p: ({ children }) => <p className="mb-2 last:mb-0">{children}</p>,
+                  strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
+                  ul: ({ children }) => <ul className="mb-2 ml-4 list-disc space-y-1">{children}</ul>,
+                  ol: ({ children }) => <ol className="mb-2 ml-4 list-decimal space-y-1">{children}</ol>,
+                  code: ({ children }) => <code className="rounded bg-black/10 px-1 py-0.5 font-mono text-xs dark:bg-white/10">{children}</code>,
+                  pre: ({ children }) => <pre className="mb-2 overflow-x-auto rounded-lg bg-black/10 p-3 font-mono text-xs dark:bg-white/10">{children}</pre>,
+                }}
+              >
+                {part.text}
+              </ReactMarkdown>
+            )
+          }
+          return null
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -11,10 +11,10 @@ import { useAuth } from "@/hooks/use-auth"
 import { useUser } from "@/hooks/use-user"
 
 function SidebarContent() {
-  const { data: chats, isLoading } = useChats()
+  const user = useUser()
+  const { data: chats, isLoading } = useChats(!!user)
   const { mutate: createChat, isPending } = useCreateChat()
   const { signOut } = useAuth()
-  const user = useUser()
 
   return (
     <div className="flex h-full flex-col">

--- a/src/hooks/use-chats.ts
+++ b/src/hooks/use-chats.ts
@@ -4,7 +4,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { useRouter } from "next/navigation"
 import type { Chat } from "@/types"
 
-export function useChats() {
+export function useChats(enabled = true) {
   return useQuery<Chat[]>({
     queryKey: ["chats"],
     queryFn: async () => {
@@ -12,6 +12,7 @@ export function useChats() {
       if (!res.ok) throw new Error("Failed to fetch chats")
       return res.json()
     },
+    enabled,
   })
 }
 

--- a/src/hooks/use-user.ts
+++ b/src/hooks/use-user.ts
@@ -9,7 +9,12 @@ export function useUser() {
 
   useEffect(() => {
     const supabase = createSupabaseBrowserClient()
-    supabase.auth.getUser().then(({ data: { user } }) => setUser(user))
+
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((_, session) => {
+      setUser(session?.user ?? null)
+    })
+
+    return () => subscription.unsubscribe()
   }, [])
 
   return user

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,7 +1,7 @@
 import { createServerClient } from "@supabase/ssr"
 import { NextRequest, NextResponse } from "next/server"
 
-export async function middleware(request: NextRequest) {
+export async function proxy(request: NextRequest) {
   let response = NextResponse.next({ request })
 
   const supabase = createServerClient(

--- a/supabase/migrations/0001_initial_schema.sql
+++ b/supabase/migrations/0001_initial_schema.sql
@@ -18,7 +18,7 @@ create table chats (
   id         uuid        primary key default gen_random_uuid(),
   user_id    uuid        not null references auth.users(id) on delete cascade,
   title      text        not null default 'New Chat',
-  model      text        not null default 'google/gemini-2.0-flash-exp',
+  model      text        not null default 'google/gemini-2.0-flash',
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now()
 );


### PR DESCRIPTION
Description
Implements the core chat functionality — sending messages, streaming AI responses, persisting to the database, and rendering markdown.

Key changes
- `POST /api/chat` — streams responses via Groq llama-3.3-70b, saves user and assistant messages to DB, auto-generates chat title on first message
- `GET /api/messages` — loads message history for a chat
- `src/app/(chat)/chat/[id]/page.tsx` — server component loading initial messages
- `Chat`, `MessageList`, `MessageInput`, `ChatMessage` — full chat UI with markdown rendering
- `proxy.ts` — replaces middleware.ts (Next.js 16 convention)
- `useUser` — switched to onAuthStateChange to fix auth race condition
- `useChats` — added enabled guard to prevent premature API calls before session is ready

Closes #9