### PR TITLE
[API][Frontend] Add image paste and attachment support

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,15 @@
 import type { NextConfig } from "next"
 
-const nextConfig: NextConfig = {}
+const nextConfig: NextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "*.supabase.co",
+        pathname: "/storage/v1/object/public/**",
+      },
+    ],
+  },
+}
 
 export default nextConfig

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -52,11 +52,16 @@ export async function POST(request: Request) {
     chat_id: chatId,
     role: "user",
     parts: lastMessage.parts,
-    attachments: [],
+    attachments: lastMessage.parts.filter((p) => p.type === "file"),
   })
 
+  const hasImages = messages.some((m) => m.parts.some((p) => p.type === "file"))
+  const model = hasImages
+    ? groq("meta-llama/llama-4-scout-17b-16e-instruct")
+    : groq("llama-3.3-70b-versatile")
+
   const result = streamText({
-    model: groq("llama-3.3-70b-versatile"),
+    model,
     messages: await convertToModelMessages(messages),
     onFinish: async ({ text }) => {
       await db.from("messages").insert({

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -1,0 +1,32 @@
+import { createSessionClient } from "@/lib/supabase/session"
+import { createServerClient } from "@/lib/supabase/server"
+import { NextResponse } from "next/server"
+
+export async function POST(request: Request) {
+  const session = await createSessionClient()
+  const {
+    data: { user },
+  } = await session.auth.getUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const formData = await request.formData()
+  const file = formData.get("file") as File | null
+  if (!file) return NextResponse.json({ error: "No file provided" }, { status: 400 })
+
+  const ext = file.name.split(".").pop() ?? "bin"
+  const path = `${user.id}/${Date.now()}.${ext}`
+  const buffer = await file.arrayBuffer()
+
+  const db = createServerClient()
+  const { error } = await db.storage
+    .from("attachments")
+    .upload(path, buffer, { contentType: file.type })
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+
+  const {
+    data: { publicUrl },
+  } = db.storage.from("attachments").getPublicUrl(path)
+
+  return NextResponse.json({ url: publicUrl, name: file.name, contentType: file.type })
+}

--- a/src/components/chat/chat.tsx
+++ b/src/components/chat/chat.tsx
@@ -7,6 +7,7 @@ import { useQueryClient } from "@tanstack/react-query"
 import { MessageList } from "./message-list"
 import { MessageInput } from "./message-input"
 import type { UIMessage } from "ai"
+import type { MessageAttachment } from "@/types"
 
 interface ChatProps {
   chatId: string
@@ -30,9 +31,19 @@ export function Chat({ chatId, initialMessages }: ChatProps) {
 
   const isLoading = status === "submitted" || status === "streaming"
 
-  const handleSend = () => {
-    if (!input.trim() || isLoading) return
-    sendMessage({ text: input })
+  const handleSend = (attachments: MessageAttachment[]) => {
+    if (!input.trim() && !attachments.length) return
+    if (isLoading) return
+
+    sendMessage({
+      text: input,
+      files: attachments.map((a) => ({
+        type: "file" as const,
+        url: a.url,
+        mediaType: a.contentType,
+        filename: a.name,
+      })),
+    })
     setInput("")
   }
 

--- a/src/components/chat/message-input.tsx
+++ b/src/components/chat/message-input.tsx
@@ -1,15 +1,16 @@
 "use client"
 
-import { useRef } from "react"
-import { ArrowUp } from "lucide-react"
+import { useRef, useState } from "react"
+import { ArrowUp, Paperclip, X } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Textarea } from "@/components/ui/textarea"
+import type { MessageAttachment } from "@/types"
 
 interface MessageInputProps {
   input: string
   isLoading: boolean
   onInputChange: (value: string) => void
-  onSend: () => void
+  onSend: (attachments: MessageAttachment[]) => void
 }
 
 export function MessageInput({
@@ -19,33 +20,107 @@ export function MessageInput({
   onSend,
 }: MessageInputProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const [attachments, setAttachments] = useState<MessageAttachment[]>([])
+  const [uploading, setUploading] = useState(false)
+
+  const uploadFile = async (file: File): Promise<MessageAttachment | null> => {
+    const formData = new FormData()
+    formData.append("file", file)
+    const res = await fetch("/api/upload", { method: "POST", body: formData })
+    if (!res.ok) return null
+    return res.json()
+  }
+
+  const handleFiles = async (files: File[]) => {
+    const images = files.filter((f) => f.type.startsWith("image/"))
+    if (!images.length) return
+    setUploading(true)
+    const results = await Promise.all(images.map(uploadFile))
+    setAttachments((prev) => [...prev, ...(results.filter(Boolean) as MessageAttachment[])])
+    setUploading(false)
+  }
+
+  const handlePaste = (e: React.ClipboardEvent) => {
+    const files = Array.from(e.clipboardData.files)
+    if (files.length) handleFiles(files)
+  }
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files) handleFiles(Array.from(e.target.files))
+    e.target.value = ""
+  }
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault()
-      onSend()
+      handleSend()
     }
   }
 
+  const handleSend = () => {
+    if ((!input.trim() && !attachments.length) || isLoading || uploading) return
+    onSend(attachments)
+    setAttachments([])
+  }
+
+  const canSend = (!!input.trim() || attachments.length > 0) && !isLoading && !uploading
+
   return (
-    <div className="flex items-end gap-2 p-4">
-      <Textarea
-        ref={textareaRef}
-        value={input}
-        onChange={(e) => onInputChange(e.target.value)}
-        onKeyDown={handleKeyDown}
-        placeholder="Message..."
-        rows={1}
-        className="min-h-10 max-h-40 flex-1 resize-none"
-        disabled={isLoading}
-      />
-      <Button
-        size="icon"
-        disabled={isLoading || !input.trim()}
-        onClick={onSend}
-      >
-        <ArrowUp className="size-4" />
-      </Button>
+    <div className="border-t p-4">
+      {attachments.length > 0 && (
+        <div className="mb-2 flex flex-wrap gap-2">
+          {attachments.map((a) => (
+            <div key={a.url} className="relative">
+              <img
+                src={a.url}
+                alt={a.name}
+                className="h-16 w-16 rounded-md object-cover"
+              />
+              <button
+                onClick={() => setAttachments((prev) => prev.filter((x) => x.url !== a.url))}
+                className="absolute -right-1 -top-1 flex size-4 items-center justify-center rounded-full bg-destructive text-destructive-foreground"
+              >
+                <X className="size-2.5" />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+      <div className="flex items-end gap-2">
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*"
+          multiple
+          className="hidden"
+          onChange={handleFileChange}
+        />
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="size-10 shrink-0"
+          onClick={() => fileInputRef.current?.click()}
+          disabled={isLoading}
+        >
+          <Paperclip className="size-4" />
+        </Button>
+        <Textarea
+          ref={textareaRef}
+          value={input}
+          onChange={(e) => onInputChange(e.target.value)}
+          onKeyDown={handleKeyDown}
+          onPaste={handlePaste}
+          placeholder="Message..."
+          rows={1}
+          className="min-h-10 max-h-40 flex-1 resize-none"
+          disabled={isLoading}
+        />
+        <Button size="icon" disabled={!canSend} onClick={handleSend}>
+          <ArrowUp className="size-4" />
+        </Button>
+      </div>
     </div>
   )
 }

--- a/src/components/chat/message.tsx
+++ b/src/components/chat/message.tsx
@@ -17,6 +17,16 @@ export function ChatMessage({ message }: { message: UIMessage }) {
         )}
       >
         {message.parts.map((part, i) => {
+          if (part.type === "file") {
+            return (
+              <img
+                key={i}
+                src={part.url}
+                alt={part.filename ?? "attachment"}
+                className="mb-2 max-w-full rounded-lg"
+              />
+            )
+          }
           if (part.type === "text") {
             return isUser ? (
               <p key={i} className="whitespace-pre-wrap break-words">

--- a/supabase/migrations/0002_storage.sql
+++ b/supabase/migrations/0002_storage.sql
@@ -1,0 +1,4 @@
+-- Storage bucket for message image attachments
+insert into storage.buckets (id, name, public)
+values ('attachments', 'attachments', true)
+on conflict do nothing;


### PR DESCRIPTION
Description
Adds image attachment support — users can paste images via Ctrl+V or use the file picker, with uploads to Supabase Storage and rendering in the chat.

Key changes
- `POST /api/upload` — uploads image to Supabase Storage, returns public URL
- `MessageInput` — paste handler, file picker button, image previews with remove
- `Chat` — passes attachments as `FileUIPart[]` via `sendMessage`
- `ChatMessage` — renders file parts (images) from message parts
- `POST /api/chat` — auto-switches to vision model when messages contain images
- `supabase/migrations/0002_storage.sql` — creates public `attachments` bucket

Closes #11