### PR TITLE
[API][Frontend] Add RAG pipeline with document upload

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,14 @@
 # Supabase - Public (used for Auth UI and Realtime only)
+# Required
 NEXT_PUBLIC_SUPABASE_URL=your_supabase_project_url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
 
 # Supabase - Server only (service role key - never expose to client)
+# Required
 SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key
 
 # LLM Providers - Server only
-GOOGLE_GENERATIVE_AI_API_KEY=your_google_ai_studio_key
+# Required: used for chat completions and vision
 GROQ_API_KEY=your_groq_api_key
+# Optional: required only if document upload (RAG) feature is used
+COHERE_API_KEY=your_cohere_api_key

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from "next"
 
 const nextConfig: NextConfig = {
+  serverExternalPackages: ["unpdf"],
   images: {
     remotePatterns: [
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "chatbot",
       "version": "0.1.0",
       "dependencies": {
+        "@ai-sdk/cohere": "^3.0.27",
         "@ai-sdk/google": "^3.0.53",
         "@ai-sdk/groq": "^3.0.31",
         "@ai-sdk/react": "^3.0.140",
@@ -33,7 +34,8 @@
         "shadcn": "^4.1.0",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
-        "tw-animate-css": "^1.4.0"
+        "tw-animate-css": "^1.4.0",
+        "unpdf": "^1.4.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -46,6 +48,22 @@
         "eslint-config-next": "16.2.1",
         "tailwindcss": "^4",
         "typescript": "^5"
+      }
+    },
+    "node_modules/@ai-sdk/cohere": {
+      "version": "3.0.27",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/cohere/-/cohere-3.0.27.tgz",
+      "integrity": "sha512-OqcCq2PiFY1dbK/0Ck45KuvE8jfdxRuuAE9Y5w46dAk6U+9vPOeg1CDcmR+ncqmrYrhRl3nmyDttyDahyjCzAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.21"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/gateway": {
@@ -11908,6 +11926,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unpdf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/unpdf/-/unpdf-1.4.0.tgz",
+      "integrity": "sha512-TahIk0xdH/4jh/MxfclzU79g40OyxtP00VnEUZdEkJoYtXAHWLiir6t3FC6z3vDqQTzc2ZHcla6uEiVTNjejuA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@napi-rs/canvas": "^0.1.69"
+      },
+      "peerDependenciesMeta": {
+        "@napi-rs/canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/unpipe": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@ai-sdk/cohere": "^3.0.27",
     "@ai-sdk/google": "^3.0.53",
     "@ai-sdk/groq": "^3.0.31",
     "@ai-sdk/react": "^3.0.140",
@@ -34,7 +35,8 @@
     "shadcn": "^4.1.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
-    "tw-animate-css": "^1.4.0"
+    "tw-animate-css": "^1.4.0",
+    "unpdf": "^1.4.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/src/app/(chat)/page.tsx
+++ b/src/app/(chat)/page.tsx
@@ -18,7 +18,7 @@ export default function HomePage() {
           Start a new conversation or select one from the sidebar
         </p>
       </div>
-      <Button onClick={() => createChat()} disabled={isPending}>
+      <Button onClick={() => createChat({})} disabled={isPending}>
         New chat
       </Button>
     </div>

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,5 +1,5 @@
-import { convertToModelMessages, generateText, streamText } from "ai"
-import { google } from "@ai-sdk/google"
+import { convertToModelMessages, embed, generateText, streamText } from "ai"
+import { cohere } from "@ai-sdk/cohere"
 import { groq } from "@ai-sdk/groq"
 import { createSessionClient } from "@/lib/supabase/session"
 import { createServerClient } from "@/lib/supabase/server"
@@ -60,8 +60,40 @@ export async function POST(request: Request) {
     ? groq("meta-llama/llama-4-scout-17b-16e-instruct")
     : groq("llama-3.3-70b-versatile")
 
+  // RAG: retrieve relevant chunks if files are attached to this chat
+  let systemPrompt: string | undefined
+  if (firstMessageText) {
+    const { data: filesExist } = await db
+      .from("files")
+      .select("id")
+      .eq("chat_id", chatId)
+      .limit(1)
+
+    if (filesExist && filesExist.length > 0) {
+      try {
+        const { embedding } = await embed({
+          model: cohere.textEmbeddingModel("embed-english-v3.0"),
+          value: firstMessageText,
+        })
+
+        const { data: chunks } = await db.rpc("match_file_items", {
+          query_embedding: JSON.stringify(embedding),
+          match_count: 5,
+          match_threshold: 0.3,
+          p_chat_id: chatId,
+        })
+
+        if (chunks && chunks.length > 0) {
+          const context = chunks.map((c: { content: string }) => c.content).join("\n\n---\n\n")
+          systemPrompt = `Use the following document context to answer the user's question when relevant:\n\n${context}`
+        }
+      } catch {}
+    }
+  }
+
   const result = streamText({
     model,
+    system: systemPrompt,
     messages: await convertToModelMessages(messages),
     onFinish: async ({ text }) => {
       await db.from("messages").insert({

--- a/src/app/api/files/[id]/route.ts
+++ b/src/app/api/files/[id]/route.ts
@@ -1,0 +1,29 @@
+import { createSessionClient } from "@/lib/supabase/session"
+import { createServerClient } from "@/lib/supabase/server"
+import { NextResponse } from "next/server"
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+
+  const session = await createSessionClient()
+  const {
+    data: { user },
+  } = await session.auth.getUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const db = createServerClient()
+
+  const { data: file } = await db.from("files").select("user_id, storage_path").eq("id", id).single()
+  if (!file || file.user_id !== user.id) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 })
+  }
+
+  await db.storage.from("files").remove([file.storage_path])
+  const { error } = await db.from("files").delete().eq("id", id)
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+
+  return new NextResponse(null, { status: 204 })
+}

--- a/src/app/api/files/route.ts
+++ b/src/app/api/files/route.ts
@@ -1,0 +1,111 @@
+import { createSessionClient } from "@/lib/supabase/session"
+import { createServerClient } from "@/lib/supabase/server"
+import { NextResponse } from "next/server"
+import { embedMany } from "ai"
+import { cohere } from "@ai-sdk/cohere"
+import { RecursiveCharacterTextSplitter } from "@langchain/textsplitters"
+import { extractText } from "@/lib/rag/extract-text"
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url)
+  const chatId = searchParams.get("chatId")
+  if (!chatId) return NextResponse.json({ error: "chatId required" }, { status: 400 })
+
+  const session = await createSessionClient()
+  const {
+    data: { user },
+  } = await session.auth.getUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const db = createServerClient()
+
+  const { data: chat } = await db.from("chats").select("user_id").eq("id", chatId).single()
+  if (!chat || chat.user_id !== user.id) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 })
+  }
+
+  const { data: files, error } = await db
+    .from("files")
+    .select("*")
+    .eq("chat_id", chatId)
+    .order("created_at", { ascending: false })
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json(files)
+}
+
+export async function POST(request: Request) {
+  const session = await createSessionClient()
+  const {
+    data: { user },
+  } = await session.auth.getUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const formData = await request.formData()
+  const file = formData.get("file") as File | null
+  const chatId = formData.get("chatId") as string | null
+  if (!file || !chatId) {
+    return NextResponse.json({ error: "file and chatId required" }, { status: 400 })
+  }
+
+  const db = createServerClient()
+
+  const { data: chat } = await db.from("chats").select("user_id").eq("id", chatId).single()
+  if (!chat || chat.user_id !== user.id) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 })
+  }
+
+  const buffer = Buffer.from(await file.arrayBuffer())
+  const ext = file.name.split(".").pop() ?? "bin"
+  const storagePath = `${user.id}/${chatId}/${Date.now()}.${ext}`
+
+  const { error: uploadError } = await db.storage
+    .from("files")
+    .upload(storagePath, buffer, { contentType: file.type })
+  if (uploadError) return NextResponse.json({ error: uploadError.message }, { status: 500 })
+
+  let text: string
+  try {
+    text = await extractText(buffer, file.type)
+  } catch (e) {
+    console.error("[files] extractText error:", e)
+    return NextResponse.json({ error: "Failed to extract text from file" }, { status: 422 })
+  }
+
+  const splitter = new RecursiveCharacterTextSplitter({ chunkSize: 1000, chunkOverlap: 200 })
+  const chunks = await splitter.splitText(text)
+
+  const { embeddings } = await embedMany({
+    model: cohere.textEmbeddingModel("embed-english-v3.0"),
+    values: chunks,
+  })
+
+  const { data: fileRecord, error: fileError } = await db
+    .from("files")
+    .insert({
+      chat_id: chatId,
+      user_id: user.id,
+      name: file.name,
+      file_type: file.type,
+      file_size: file.size,
+      storage_path: storagePath,
+      tokens: chunks.length,
+    })
+    .select()
+    .single()
+
+  if (fileError) return NextResponse.json({ error: fileError.message }, { status: 500 })
+
+  const fileItems = chunks.map((content, i) => ({
+    file_id: fileRecord.id,
+    chat_id: chatId,
+    content,
+    embedding: JSON.stringify(embeddings[i]),
+    chunk_index: i,
+  }))
+
+  const { error: itemsError } = await db.from("file_items").insert(fileItems)
+  if (itemsError) return NextResponse.json({ error: itemsError.message }, { status: 500 })
+
+  return NextResponse.json(fileRecord, { status: 201 })
+}

--- a/src/components/chat/chat.tsx
+++ b/src/components/chat/chat.tsx
@@ -6,6 +6,7 @@ import { DefaultChatTransport } from "ai"
 import { useQueryClient } from "@tanstack/react-query"
 import { MessageList } from "./message-list"
 import { MessageInput } from "./message-input"
+import { FileUpload } from "./file-upload"
 import type { UIMessage } from "ai"
 import type { MessageAttachment } from "@/types"
 
@@ -50,6 +51,7 @@ export function Chat({ chatId, initialMessages }: ChatProps) {
   return (
     <div className="flex flex-1 flex-col overflow-hidden">
       <MessageList messages={messages} isLoading={isLoading} />
+      <FileUpload chatId={chatId} />
       <MessageInput
         input={input}
         isLoading={isLoading}

--- a/src/components/chat/file-upload.tsx
+++ b/src/components/chat/file-upload.tsx
@@ -1,0 +1,85 @@
+"use client"
+
+import { useRef, useState } from "react"
+import { FileText, Paperclip, X } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
+import type { ChatFile } from "@/types"
+
+interface FileUploadProps {
+  chatId: string
+}
+
+export function FileUpload({ chatId }: FileUploadProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const [uploading, setUploading] = useState(false)
+  const queryClient = useQueryClient()
+
+  const { data: files } = useQuery<ChatFile[]>({
+    queryKey: ["files", chatId],
+    queryFn: async () => {
+      const res = await fetch(`/api/files?chatId=${chatId}`)
+      if (!res.ok) throw new Error("Failed to fetch files")
+      return res.json()
+    },
+  })
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    setUploading(true)
+    const formData = new FormData()
+    formData.append("file", file)
+    formData.append("chatId", chatId)
+    await fetch("/api/files", { method: "POST", body: formData })
+    await queryClient.invalidateQueries({ queryKey: ["files", chatId] })
+    setUploading(false)
+    e.target.value = ""
+  }
+
+  const handleDelete = async (id: string) => {
+    await fetch(`/api/files/${id}`, { method: "DELETE" })
+    queryClient.invalidateQueries({ queryKey: ["files", chatId] })
+  }
+
+  return (
+    <div className="px-4 pb-2">
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".pdf,.docx,.txt,.md"
+        className="hidden"
+        onChange={handleFileChange}
+      />
+      {files && files.length > 0 && (
+        <div className="mb-2 flex flex-wrap gap-2">
+          {files.map((f) => (
+            <div
+              key={f.id}
+              className="flex items-center gap-1.5 rounded-full bg-muted px-3 py-1 text-xs"
+            >
+              <FileText className="size-3 shrink-0" />
+              <span className="max-w-[140px] truncate">{f.name}</span>
+              <button
+                onClick={() => handleDelete(f.id)}
+                className="ml-0.5 text-muted-foreground hover:text-foreground"
+              >
+                <X className="size-3" />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+      <Button
+        variant="ghost"
+        size="sm"
+        className="h-7 gap-1.5 text-xs text-muted-foreground"
+        onClick={() => fileInputRef.current?.click()}
+        disabled={uploading}
+      >
+        <Paperclip className="size-3" />
+        {uploading ? "Uploading..." : "Attach document"}
+      </Button>
+    </div>
+  )
+}

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -22,7 +22,7 @@ function SidebarContent() {
         <Button
           className="w-full justify-start gap-2"
           variant="outline"
-          onClick={() => createChat()}
+          onClick={() => createChat({})}
           disabled={isPending}
         >
           <Plus className="size-4" />

--- a/src/lib/rag/extract-text.ts
+++ b/src/lib/rag/extract-text.ts
@@ -1,0 +1,21 @@
+import "server-only"
+import { extractText as extractPdfText } from "unpdf"
+import mammoth from "mammoth"
+
+export async function extractText(buffer: Buffer, fileType: string): Promise<string> {
+  switch (fileType) {
+    case "application/pdf": {
+      const { text } = await extractPdfText(new Uint8Array(buffer))
+      return Array.isArray(text) ? text.join("\n\n") : text
+    }
+    case "application/vnd.openxmlformats-officedocument.wordprocessingml.document": {
+      const result = await mammoth.extractRawText({ buffer })
+      return result.value
+    }
+    case "text/plain":
+    case "text/markdown":
+      return buffer.toString("utf-8")
+    default:
+      throw new Error(`Unsupported file type: ${fileType}`)
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,6 +16,7 @@ export interface MessageAttachment {
   type: "image"
   url: string
   name: string
+  contentType: string
 }
 
 // Database row types

--- a/supabase/migrations/0003_files_storage.sql
+++ b/supabase/migrations/0003_files_storage.sql
@@ -1,0 +1,4 @@
+-- Private storage bucket for uploaded documents (PDF, DOCX, TXT, MD)
+insert into storage.buckets (id, name, public)
+values ('files', 'files', false)
+on conflict do nothing;

--- a/supabase/migrations/0004_update_embedding_dim.sql
+++ b/supabase/migrations/0004_update_embedding_dim.sql
@@ -1,0 +1,38 @@
+-- Update embedding dimension from 768 (Google text-embedding-004)
+-- to 1024 (Mistral mistral-embed)
+alter table file_items alter column embedding type vector(1024);
+
+drop index if exists file_items_embedding_idx;
+create index file_items_embedding_idx on file_items
+  using hnsw (embedding vector_cosine_ops)
+  with (m = 16, ef_construction = 64);
+
+-- Update match_file_items function signature
+create or replace function match_file_items(
+  query_embedding vector(1024),
+  match_count     int,
+  match_threshold float,
+  p_chat_id       uuid
+)
+returns table (
+  id          uuid,
+  file_id     uuid,
+  content     text,
+  chunk_index int,
+  similarity  float
+)
+language sql stable
+as $$
+  select
+    fi.id,
+    fi.file_id,
+    fi.content,
+    fi.chunk_index,
+    1 - (fi.embedding <=> query_embedding) as similarity
+  from file_items fi
+  where fi.chat_id = p_chat_id
+    and fi.embedding is not null
+    and 1 - (fi.embedding <=> query_embedding) > match_threshold
+  order by fi.embedding <=> query_embedding
+  limit match_count;
+$$;


### PR DESCRIPTION
Description
Adds document upload and RAG retrieval pipeline — users can attach PDF, DOCX, TXT, or MD files to a chat, which are chunked, embedded via Cohere, and used as context for subsequent messages.

Key changes
- `POST /api/files` — upload handler with text extraction, chunking, and vector embeddings via Cohere `embed-english-v3.0`
- `DELETE /api/files/[id]` — delete file with Supabase Storage cleanup
- `FileUpload` — persistent file chips per chat with delete support
- `POST /api/chat` — integrates RAG retrieval, injects relevant chunks as system prompt
- `lib/rag/extract-text` — text extraction for PDF (`unpdf`), DOCX (`mammoth`), TXT/MD
- `supabase/migrations/0004` — updates pgvector dimension from 768 to 1024

Closes #13