### PR TITLE
[API][Frontend] Add anonymous access with 3-message limit

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -43,6 +43,25 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Not found" }, { status: 404 })
   }
 
+  if (user.is_anonymous) {
+    const { data: userChats } = await db
+      .from("chats")
+      .select("id")
+      .eq("user_id", user.id)
+
+    const chatIds = (userChats ?? []).map((c) => c.id)
+
+    const { count } = await db
+      .from("messages")
+      .select("id", { count: "exact", head: true })
+      .eq("role", "user")
+      .in("chat_id", chatIds)
+
+    if ((count ?? 0) >= 3) {
+      return NextResponse.json({ error: "Anonymous limit reached" }, { status: 403 })
+    }
+  }
+
   const lastMessage = messages[messages.length - 1]
   const isFirstMessage = messages.length === 1
   const firstMessageText =

--- a/src/components/chat/chat.tsx
+++ b/src/components/chat/chat.tsx
@@ -4,9 +4,18 @@ import { useState } from "react"
 import { useChat } from "@ai-sdk/react"
 import { DefaultChatTransport } from "ai"
 import { useQueryClient } from "@tanstack/react-query"
+import { useRouter } from "next/navigation"
 import { MessageList } from "./message-list"
 import { MessageInput } from "./message-input"
 import { FileUpload } from "./file-upload"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
 import type { UIMessage } from "ai"
 import type { MessageAttachment } from "@/types"
 
@@ -17,7 +26,9 @@ interface ChatProps {
 
 export function Chat({ chatId, initialMessages }: ChatProps) {
   const queryClient = useQueryClient()
+  const router = useRouter()
   const [input, setInput] = useState("")
+  const [showAuthModal, setShowAuthModal] = useState(false)
 
   const { messages, sendMessage, status } = useChat({
     messages: initialMessages,
@@ -27,6 +38,11 @@ export function Chat({ chatId, initialMessages }: ChatProps) {
     }),
     onFinish: () => {
       queryClient.invalidateQueries({ queryKey: ["chats"] })
+    },
+    onError: (error) => {
+      if (error.message.includes("Anonymous limit reached")) {
+        setShowAuthModal(true)
+      }
     },
   })
 
@@ -58,6 +74,25 @@ export function Chat({ chatId, initialMessages }: ChatProps) {
         onInputChange={setInput}
         onSend={handleSend}
       />
+
+      <Dialog open={showAuthModal} onOpenChange={setShowAuthModal}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Free limit reached</DialogTitle>
+            <DialogDescription>
+              You&apos;ve used your 3 free messages. Create an account to continue chatting.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex gap-2 justify-end">
+            <Button variant="outline" onClick={() => router.push("/login")}>
+              Log in
+            </Button>
+            <Button onClick={() => router.push("/register")}>
+              Sign up
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }


### PR DESCRIPTION
Description
Limits anonymous (guest) users to 3 messages. After the limit, a modal prompts them to log in or sign up.

Key changes
- `POST /api/chat` — checks `user.is_anonymous`, counts user messages across all their chats, returns 403 if ≥ 3
- `Chat` — handles 403 in `onError`, shows auth modal with Log in / Sign up buttons

Closes #16