### PR TITLE
[Realtime] Add cross-tab sync via Supabase Realtime

### DIFF
--- a/src/components/chat/chat.tsx
+++ b/src/components/chat/chat.tsx
@@ -8,6 +8,7 @@ import { useRouter } from "next/navigation"
 import { MessageList } from "./message-list"
 import { MessageInput } from "./message-input"
 import { FileUpload } from "./file-upload"
+import { useMessagesSync } from "@/hooks/use-messages-sync"
 import {
   Dialog,
   DialogContent,
@@ -30,7 +31,7 @@ export function Chat({ chatId, initialMessages }: ChatProps) {
   const [input, setInput] = useState("")
   const [showAuthModal, setShowAuthModal] = useState(false)
 
-  const { messages, sendMessage, status } = useChat({
+  const { messages, setMessages, sendMessage, status } = useChat({
     messages: initialMessages,
     transport: new DefaultChatTransport({
       api: "/api/chat",
@@ -47,6 +48,8 @@ export function Chat({ chatId, initialMessages }: ChatProps) {
   })
 
   const isLoading = status === "submitted" || status === "streaming"
+
+  useMessagesSync({ chatId, messages, setMessages, isStreaming: isLoading })
 
   const handleSend = (attachments: MessageAttachment[]) => {
     if (!input.trim() && !attachments.length) return

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -6,13 +6,14 @@ import { ScrollArea } from "@/components/ui/scroll-area"
 import { Separator } from "@/components/ui/separator"
 import { Skeleton } from "@/components/ui/skeleton"
 import { SidebarItem } from "./sidebar-item"
-import { useChats, useCreateChat } from "@/hooks/use-chats"
+import { useChats, useChatsSync, useCreateChat } from "@/hooks/use-chats"
 import { useAuth } from "@/hooks/use-auth"
 import { useUser } from "@/hooks/use-user"
 
 function SidebarContent() {
   const user = useUser()
   const { data: chats, isLoading } = useChats(!!user)
+  useChatsSync(user?.id)
   const { mutate: createChat, isPending } = useCreateChat()
   const { signOut } = useAuth()
 

--- a/src/hooks/use-chats.ts
+++ b/src/hooks/use-chats.ts
@@ -1,8 +1,34 @@
 "use client"
 
+import { useEffect } from "react"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { useRouter } from "next/navigation"
 import type { Chat } from "@/types"
+import { createSupabaseBrowserClient } from "@/lib/supabase/browser"
+
+export function useChatsSync(userId: string | undefined) {
+  const queryClient = useQueryClient()
+
+  useEffect(() => {
+    if (!userId) return
+
+    const supabase = createSupabaseBrowserClient()
+    const channel = supabase
+      .channel("chats-sync")
+      .on(
+        "postgres_changes",
+        { event: "*", schema: "public", table: "chats", filter: `user_id=eq.${userId}` },
+        () => {
+          queryClient.invalidateQueries({ queryKey: ["chats"] })
+        }
+      )
+      .subscribe()
+
+    return () => {
+      supabase.removeChannel(channel)
+    }
+  }, [userId, queryClient])
+}
 
 export function useChats(enabled = true) {
   return useQuery<Chat[]>({

--- a/src/hooks/use-messages-sync.ts
+++ b/src/hooks/use-messages-sync.ts
@@ -1,0 +1,46 @@
+"use client"
+
+import { useEffect } from "react"
+import type { UIMessage } from "ai"
+import { createSupabaseBrowserClient } from "@/lib/supabase/browser"
+import type { Message } from "@/types"
+
+interface UseMessagesSyncOptions {
+  chatId: string
+  messages: UIMessage[]
+  setMessages: (messages: UIMessage[] | ((prev: UIMessage[]) => UIMessage[])) => void
+  isStreaming: boolean
+}
+
+export function useMessagesSync({ chatId, messages, setMessages, isStreaming }: UseMessagesSyncOptions) {
+  useEffect(() => {
+    const supabase = createSupabaseBrowserClient()
+
+    const channel = supabase
+      .channel(`messages-sync-${chatId}`)
+      .on(
+        "postgres_changes",
+        { event: "INSERT", schema: "public", table: "messages", filter: `chat_id=eq.${chatId}` },
+        (payload) => {
+          if (isStreaming) return
+
+          const row = payload.new as Message
+          const alreadyExists = messages.some((m) => m.id === row.id)
+          if (alreadyExists) return
+
+          const newMessage: UIMessage = {
+            id: row.id,
+            role: row.role,
+            parts: row.parts as UIMessage["parts"],
+          }
+
+          setMessages((prev) => [...prev, newMessage])
+        }
+      )
+      .subscribe()
+
+    return () => {
+      supabase.removeChannel(channel)
+    }
+  }, [chatId, isStreaming, messages, setMessages])
+}

--- a/supabase/migrations/0005_enable_realtime.sql
+++ b/supabase/migrations/0005_enable_realtime.sql
@@ -1,0 +1,3 @@
+-- Enable Realtime for cross-tab sync on chats and messages tables
+alter publication supabase_realtime add table chats;
+alter publication supabase_realtime add table messages;


### PR DESCRIPTION
Description
Synchronises the chat list and open chat messages across browser tabs in real time using Supabase Realtime Postgres Changes.

Key changes
- `supabase/migrations/0005_enable_realtime.sql` — enable Realtime publication for `chats` and `messages` tables
- `use-chats.ts` — `useChatsSync(userId)`: subscribes to `chats` changes, invalidates React Query cache on any event
- `use-messages-sync.ts` — `useMessagesSync(...)`: subscribes to `messages` INSERT, appends new messages from other tabs, skips during active streaming
- `sidebar.tsx` — calls `useChatsSync`
- `chat.tsx` — calls `useMessagesSync`

Closes #18