### PR TITLE
[Frontend] UI polish: theme, fonts, title, mobile layout

### DIFF
--- a/src/app/(chat)/chat/[id]/page.tsx
+++ b/src/app/(chat)/chat/[id]/page.tsx
@@ -2,7 +2,19 @@ import { notFound, redirect } from "next/navigation"
 import { createSessionClient } from "@/lib/supabase/session"
 import { createServerClient } from "@/lib/supabase/server"
 import { Chat } from "@/components/chat/chat"
+import type { Metadata } from "next"
 import type { UIMessage } from "ai"
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}): Promise<Metadata> {
+  const { id } = await params
+  const db = createServerClient()
+  const { data: chat } = await db.from("chats").select("title").eq("id", id).single()
+  return { title: chat?.title ?? "Chat" }
+}
 
 export default async function ChatPage({
   params,

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -91,7 +91,7 @@ export async function POST(request: Request) {
     if (filesExist && filesExist.length > 0) {
       try {
         const { embedding } = await embed({
-          model: cohere.textEmbeddingModel("embed-english-v3.0"),
+          model: cohere.embeddingModel("embed-english-v3.0"),
           value: firstMessageText,
         })
 

--- a/src/app/api/files/route.ts
+++ b/src/app/api/files/route.ts
@@ -76,7 +76,7 @@ export async function POST(request: Request) {
   const chunks = await splitter.splitText(text)
 
   const { embeddings } = await embedMany({
-    model: cohere.textEmbeddingModel("embed-english-v3.0"),
+    model: cohere.embeddingModel("embed-english-v3.0"),
     values: chunks,
   })
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,7 +7,7 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-sans);
+  --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
   --font-heading: var(--font-sans);
   --color-sidebar-ring: var(--sidebar-ring);
@@ -125,6 +125,6 @@
     @apply bg-background text-foreground;
   }
   html {
-    @apply font-sans;
+    font-family: var(--font-geist-sans), ui-sans-serif, system-ui, sans-serif;
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,7 +15,10 @@ const geistMono = Geist_Mono({
 })
 
 export const metadata: Metadata = {
-  title: "Chatbot",
+  title: {
+    default: "Chatbot",
+    template: "%s | Chatbot",
+  },
   description: "AI-powered chat interface",
 }
 
@@ -27,8 +30,16 @@ export default function RootLayout({
   return (
     <html
       lang="en"
+      suppressHydrationWarning
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
+      <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(){var t=localStorage.getItem('theme')||'system';if(t==='dark'||(t==='system'&&matchMedia('(prefers-color-scheme:dark)').matches))document.documentElement.classList.add('dark')})()`,
+          }}
+        />
+      </head>
       <body className="h-full">
         <Providers>
           <AuthInitializer />

--- a/src/components/chat/file-upload.tsx
+++ b/src/components/chat/file-upload.tsx
@@ -38,6 +38,9 @@ export function FileUpload({ chatId }: FileUploadProps) {
   }
 
   const handleDelete = async (id: string) => {
+    queryClient.setQueryData<ChatFile[]>(["files", chatId], (prev) =>
+      prev ? prev.filter((f) => f.id !== id) : prev
+    )
     await fetch(`/api/files/${id}`, { method: "DELETE" })
     queryClient.invalidateQueries({ queryKey: ["files", chatId] })
   }

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -1,6 +1,7 @@
 "use client"
 
-import { LogOut, Plus } from "lucide-react"
+import { LogOut, Moon, Plus, Sun } from "lucide-react"
+import { useTheme } from "@/hooks/use-theme"
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Separator } from "@/components/ui/separator"
@@ -16,6 +17,7 @@ function SidebarContent() {
   useChatsSync(user?.id)
   const { mutate: createChat, isPending } = useCreateChat()
   const { signOut } = useAuth()
+  const { resolvedTheme, setTheme } = useTheme()
 
   return (
     <div className="flex h-full flex-col">
@@ -61,6 +63,14 @@ function SidebarContent() {
             {user?.is_anonymous ? "Guest" : user?.email}
           </p>
         </div>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-8 shrink-0"
+          onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
+        >
+          {resolvedTheme === "dark" ? <Sun className="size-4" /> : <Moon className="size-4" />}
+        </Button>
         <Button variant="ghost" size="icon" className="size-8 shrink-0" onClick={signOut}>
           <LogOut className="size-4" />
         </Button>

--- a/src/hooks/use-theme.ts
+++ b/src/hooks/use-theme.ts
@@ -1,0 +1,29 @@
+"use client"
+
+import { useEffect, useState } from "react"
+
+type Theme = "light" | "dark" | "system"
+
+function resolve(theme: Theme): "light" | "dark" {
+  if (theme === "dark") return "dark"
+  if (theme === "light") return "light"
+  return matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light"
+}
+
+export function useTheme() {
+  const [resolvedTheme, setResolvedTheme] = useState<"light" | "dark">("light")
+
+  useEffect(() => {
+    const stored = (localStorage.getItem("theme") as Theme) || "system"
+    setResolvedTheme(resolve(stored))
+  }, [])
+
+  const setTheme = (theme: Theme) => {
+    localStorage.setItem("theme", theme)
+    const resolved = resolve(theme)
+    document.documentElement.classList.toggle("dark", resolved === "dark")
+    setResolvedTheme(resolved)
+  }
+
+  return { resolvedTheme, setTheme }
+}


### PR DESCRIPTION
Description
UI polish pass covering theme toggle, font fix, dynamic page titles, mobile sidebar, and UX fixes.

Key changes
- `src/hooks/use-theme.ts` — custom theme hook with localStorage + FOUC-prevention script; replaces `next-themes` which is incompatible with React 19
- `src/app/globals.css` — fix font-family circular reference, use `var(--font-geist-sans)` directly
- `src/app/layout.tsx` — title template (`%s | Chatbot`), FOUC script in `<head>`
- `src/app/(chat)/chat/[id]/page.tsx` — `generateMetadata` for dynamic chat title
- `src/components/layout/sidebar.tsx` — dark/light toggle button in footer
- `src/components/providers.tsx` — remove `next-themes` ThemeProvider
- `src/components/chat/file-upload.tsx` — optimistic delete so chip disappears immediately
- `src/app/api/chat/route.ts`, `src/app/api/files/route.ts` — replace deprecated `textEmbeddingModel` with `embeddingModel`

Closes #20